### PR TITLE
Ferg20170603

### DIFF
--- a/lib/dlibhydra/services/solr_query.rb
+++ b/lib/dlibhydra/services/solr_query.rb
@@ -6,10 +6,8 @@ require 'yaml'
 module Dlibhydra
   class SolrQuery
 
-    CONN = RSolr.connect :url => YAML.load_file('config/solr.yml')[Rails.env]['url']
-
     def solr_query(q, fl='id', rows=10, sort='', start=0)
-      CONN.get 'select', :params => {
+      ActiveFedora::SolrService.get 'select', :params => {
           :q => q,
           :fl => fl,
           :rows => rows,

--- a/lib/dlibhydra/services/solr_query.rb
+++ b/lib/dlibhydra/services/solr_query.rb
@@ -7,7 +7,7 @@ module Dlibhydra
   class SolrQuery
 
     def solr_query(q, fl='id', rows=10, sort='', start=0)
-      ActiveFedora::SolrService.get('select', :params => {
+      ActiveFedora::SolrService.instance.conn.get('select', :params => {
           :q => q,
           :fl => fl,
           :rows => rows,

--- a/lib/dlibhydra/services/solr_query.rb
+++ b/lib/dlibhydra/services/solr_query.rb
@@ -7,13 +7,13 @@ module Dlibhydra
   class SolrQuery
 
     def solr_query(q, fl='id', rows=10, sort='', start=0)
-      ActiveFedora::SolrService.get 'select', :params => {
+      ActiveFedora::SolrService.get('select', :params => {
           :q => q,
           :fl => fl,
           :rows => rows,
           :sort => sort,
           :start => start
-      }
+      })
     end
   end
 end

--- a/lib/dlibhydra/services/solr_query.rb
+++ b/lib/dlibhydra/services/solr_query.rb
@@ -7,6 +7,7 @@ module Dlibhydra
   class SolrQuery
 
     def solr_query(q, fl='id', rows=10, sort='', start=0)
+      # use the solr instance already loaded in ActiveFedora rather than digging it out of config/solr.yml (which might contain ERB)
       ActiveFedora::SolrService.instance.conn.get('select', :params => {
           :q => q,
           :fl => fl,


### PR DESCRIPTION
At present, when dlibhydra runs a solr query, it sets up a new solr connection based on the values it finds in config/solr.yml, but this doesn't work if the values in config/solr.yml are expressed in ERB. For example, in config/solr.yml:

development:
  url: <%= ENV['SOLR_DEV'] %> 
production:
  url: <%= ENV['SOLR_PROD'] %>

Dlibhydra currently treats those bits of ERB literally. There isn't really any need for dlibhydra to set up a new solr connection because ActiveFedora already has it defined, and it has read the config/solr.yml file correctly, so we should just use the ActiveFedora solr connection.

Tested on rdyork application - works fine there.